### PR TITLE
Add Google Ads tracking snippets to service pages

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,12 +1,26 @@
 import ContactSection from '@/sections/contact-section'
 import React from 'react'
+import Head from 'next/head'
 
 type Props = {}
 
 export default function page({ }: Props) {
     return (
-        <div>
-            <ContactSection />
-        </div>
+        <>
+            <Head>
+                <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17385017560" />
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'AW-17385017560');`
+                    }}
+                />
+            </Head>
+            <div>
+                <ContactSection />
+            </div>
+        </>
     )
 }

--- a/app/services/Jetting/[[...city]]/page.tsx
+++ b/app/services/Jetting/[[...city]]/page.tsx
@@ -92,26 +92,40 @@ export default async function Page({ params }: { params: Promise<{ city?: string
 
   return (<>
     <Head>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17385017560" />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'AW-17385017560');
+function gtag_report_conversion_whatsapp(url){var callback=function(){if(typeof(url)!='undefined'){window.location=url;}};gtag('event','conversion',{'send_to':'AW-17385017560/_ZT_CPPR3vsaENih6eFA','event_callback':callback});return false;}
+function gtag_report_conversion_call(url){var callback=function(){if(typeof(url)!='undefined'){window.location=url;}};gtag('event','conversion',{'send_to':'AW-17385017560/B-xnCPSPyfcaENih6eFA','event_callback':callback});return false;}`
+        }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "https://schema.org",
-          "@type": "LocalBusiness",
-          "name": "אקו פתרונות אינסטלציה",
-          "image": "https://www.eco-plumbers.com/images/jetter-service.png",
-          "telephone": "+972526736935",
-          "address": {
-            "@type": "PostalAddress",
-            "addressLocality": cityName?.replace("ב", ""),
-            "addressCountry": "IL"
-          },
-          "url": `https://www.eco-plumbers.com/services/jetting/${cityName?.replace("ב", "")}`,
-          "openingHours": "24/7"
-        })
-      }} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "LocalBusiness",
+            "name": "אקו פתרונות אינסטלציה",
+            "image": "https://www.eco-plumbers.com/images/jetter-service.png",
+            "telephone": "+972526736935",
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": cityName?.replace("ב", ""),
+              "addressCountry": "IL"
+            },
+            "url": `https://www.eco-plumbers.com/services/jetting/${cityName?.replace("ב", "")}`,
+            "openingHours": "24/7"
+          })
+        }}
+      />
     </Head>
     <div className="relative overflow-hidden rtl">
       <div className="absolute top-20 -left-20 w-80 h-80 bg-secondary-text rounded-full opacity-20" />
@@ -130,7 +144,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
             <span className="font-bold">התחייבות לשירות מקצועי – לא פתרנו? לא שילמתם.</span><br />
             זמינות גם בשבתות וחגים.
           </p>
-          <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+          <a
+            href="tel:0526736935"
+            onClick={() => gtag_report_conversion_call('tel:0526736935')}
+            className={filledButton + " m-auto mt-8 block"}
+          >
             ☎️ התקשרו עכשיו וקבלו צילום קו במתנה עם כל שירות: 052-6736935
           </a>
           <a target="blank" href="https://www.midrag.co.il/SpCard/Sp/128232?sectorId=4&listId=2" className={filledButton + " m-auto mt-8 block bg-pink-600 "}>
@@ -167,7 +185,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                   <li>שירות חירום 24/7</li>
                 </ul>
               </div>
-              <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+              <a
+                href="tel:0526736935"
+                onClick={() => gtag_report_conversion_call('tel:0526736935')}
+                className={filledButton + " m-auto mt-8 block"}
+              >
                 ☎️ אני רוצה שתגיעו!
               </a>
             </div>
@@ -191,7 +213,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
 
         {/* FAQ Accordion */}
         <TogglesGenerator questions={items} />
-        <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+        <a
+          href="tel:0526736935"
+          onClick={() => gtag_report_conversion_call('tel:0526736935')}
+          className={filledButton + " m-auto mt-8 block"}
+        >
           ☎️ יש לכם עוד שאלות? התקשרו לייעוץ חינם!
         </a>
 
@@ -208,7 +234,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
           <p className="mb-6 text-lg text-primary-text">
             השאר פרטים ונחזור תוך דקות – או התקשר עכשיו ואנחנו מגיעים עם ביובית מקצועית וציוד מתקדם
           </p>
-          <a href="https://wa.me/972526736935" className={filledButton + " mt-4 bg-green-600"}>
+          <a
+            href="https://wa.me/972526736935"
+            onClick={() => gtag_report_conversion_whatsapp('https://wa.me/972526736935')}
+            className={filledButton + " mt-4 bg-green-600"}
+          >
             💬 שלחו לנו וואטסאפ עכשיו
           </a>
 

--- a/app/services/leak-detection/[[...city]]/page.tsx
+++ b/app/services/leak-detection/[[...city]]/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { filledButton } from "@/components/buttons";
 import TogglesGenerator from "@/components/toggles-generator";
 import ReviewsSlider from "@/sections/reviews";
+import Head from "next/head";
 
 const items = [
     {
@@ -69,6 +70,20 @@ export default async function Page({ params }: { params: Promise<{ city?: string
     const cityName = city ? "ב" + decodeURIComponent(city[0]) : null;
 
     return (
+        <>
+        <Head>
+            <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17385017560" />
+            <script
+                dangerouslySetInnerHTML={{
+                    __html: `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'AW-17385017560');
+function gtag_report_conversion_whatsapp(url){var callback=function(){if(typeof(url)!='undefined'){window.location=url;}};gtag('event','conversion',{'send_to':'AW-17385017560/8kh_CKCR3_saENih6eFA','event_callback':callback});return false;}
+function gtag_report_conversion_call(url){var callback=function(){if(typeof(url)!='undefined'){window.location=url;}};gtag('event','conversion',{'send_to':'AW-17385017560/pZqJCLDbyfcaENih6eFA','event_callback':callback});return false;}`
+                }}
+            />
+        </Head>
         <div className="relative overflow-hidden rtl">
             <div className="absolute top-20 -left-20 w-80 h-80 bg-secondary-text rounded-full opacity-20" />
             <div className="absolute -bottom-20 -right-20 w-40 h-40 bg-secondary-text rounded-full opacity-20" />
@@ -84,7 +99,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                     <p className="text-lg md:text-xl max-w-3xl mx-auto text-primary-sea ">
                         מצלמות תרמיות, ציוד אקוסטי, דוחות מקצועיים ופתרון מדויק – בלי לנחש, בלי לשבור, בלי הפתעות, עובדים מסביב לשעון גם בשבתות וחגים, מתחייבים לשירות הטוב ביותר , <span className="font-bold">לא איתרנו, לא שילמתם</span>!
                     </p>
-                    <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+                    <a
+                        href="tel:0526736935"
+                        onClick={() => gtag_report_conversion_call('tel:0526736935')}
+                        className={filledButton + " m-auto mt-8 block"}
+                    >
                         ☎️ רוצים שנאתר את הנזילה עוד היום? התקשרו - 052-6736935
                     </a>
                     <a target="blank" href="https://www.midrag.co.il/SpCard/Sp/128232?sectorId=4&listId=2" className={filledButton + " m-auto mt-8 block bg-pink-600 "}>
@@ -122,7 +141,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                                 </ul>
                             </div>
 
-                            <a href="tel:0526736935" className={filledButton + " m-auto mt-10 block  text-center"}>
+                            <a
+                                href="tel:0526736935"
+                                onClick={() => gtag_report_conversion_call('tel:0526736935')}
+                                className={filledButton + " m-auto mt-10 block  text-center"}
+                            >
                                 לא בטוחים? לחצו כאן לשיחת יעוץ חינם
                             </a>
                         </div>
@@ -163,7 +186,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                             </div>
                         </div>
                     </section>
-                    <a href="tel:0526736935" className={filledButton + " m-auto mt-8"}>
+                    <a
+                        href="tel:0526736935"
+                        onClick={() => gtag_report_conversion_call('tel:0526736935')}
+                        className={filledButton + " m-auto mt-8"}
+                    >
                         ☎️ לשיחת ייעוץ חינם חייגו
                     </a>
                 </div>
@@ -184,7 +211,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                     <p className="mb-6 text-lg text-primary-text">
                         השאר פרטים ונחזור אליך תוך דקות – או התקשר עכשיו ונגיע עם ציוד תרמי לאיתור מיידי
                     </p>
-                    <a href="tel:0526736935" className={filledButton}>
+                    <a
+                        href="tel:0526736935"
+                        onClick={() => gtag_report_conversion_call('tel:0526736935')}
+                        className={filledButton}
+                    >
                         ☎️ דברו איתנו עכשיו
                     </a>
                 </div>
@@ -192,5 +223,6 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                 <ContactSection />
             </div>
         </div>
+        </>
     );
 }

--- a/app/services/no-dig-solutions/[[...city]]/page.tsx
+++ b/app/services/no-dig-solutions/[[...city]]/page.tsx
@@ -2,6 +2,7 @@ import ContactSection from "@/sections/contact-section";
 import Image from "next/image";
 import { filledButton } from "@/components/buttons";
 import TogglesGenerator from "@/components/toggles-generator";
+import Head from "next/head";
 
 const items = [
   {
@@ -64,6 +65,20 @@ export default async function Page({ params }: { params: Promise<{ city?: string
   const cityName = city ? "ב" + decodeURIComponent(city[0]) : null;
 
   return (
+    <>
+    <Head>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17385017560" />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'AW-17385017560');
+function gtag_report_conversion_whatsapp(url){var callback=function(){if(typeof(url)!='undefined'){window.location=url;}};gtag('event','conversion',{'send_to':'AW-17385017560/iGzDCMnG2vsaENih6eFA','event_callback':callback});return false;}
+function gtag_report_conversion_call(url){var callback=function(){if(typeof(url)!='undefined'){window.location=url;}};gtag('event','conversion',{'send_to':'AW-17385017560/kVxnCL--vPcaENih6eFA','event_callback':callback});return false;}`
+        }}
+      />
+    </Head>
     <div className="relative overflow-hidden rtl">
       <div className="absolute top-20 -left-20 w-80 h-80 bg-secondary-text rounded-full opacity-20" />
       <div className="absolute -bottom-20 -right-20 w-40 h-40 bg-secondary-text rounded-full opacity-20" />
@@ -155,7 +170,11 @@ export default async function Page({ params }: { params: Promise<{ city?: string
           <p className="mb-6 text-lg text-primary-text">
             השאר פרטים ונחזור אליך – או התקשר עכשיו ונתאם ביקור לבדיקה וצילום קו
           </p>
-          <a href="tel:0526736935" className={filledButton}>
+          <a
+            href="tel:0526736935"
+            onClick={() => gtag_report_conversion_call('tel:0526736935')}
+            className={filledButton}
+          >
             ☎️ דברו איתנו עכשיו
           </a>
         </div>
@@ -163,5 +182,6 @@ export default async function Page({ params }: { params: Promise<{ city?: string
         <ContactSection />
       </div>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- embed Google Ads gtag and conversion handlers on Jetting, Leak Detection, No-Dig Solutions, and Contact pages
- wire phone and WhatsApp links to trigger conversion events

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive ESLint setup required)
- `npm run build` (fails: Failed to fetch fonts from Google)


------
https://chatgpt.com/codex/tasks/task_e_688da964e5d0832c95fe9f8f1b90e1bf