### PR TITLE
Add Google Ads tracking snippets to service pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { GoogleAnalytics } from '@next/third-parties/google'
 import ClarityInit from "@/components/clarity";
+import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -88,6 +89,18 @@ export default function RootLayout({
             }
           })}
         </script>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=AW-17385017560"
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'AW-17385017560');
+          `}
+        </Script>
       </head>
       <body className="relative">
         <Header />

--- a/app/services/Jetting/[[...city]]/page.tsx
+++ b/app/services/Jetting/[[...city]]/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { filledButton } from "@/components/buttons";
 import ReviewsSlider from "@/sections/reviews";
 import Head from "next/head";
+import ConversionLink from "@/components/ConversionLink";
 
 const items = [
   {
@@ -96,22 +97,25 @@ export default async function Page({ params }: { params: Promise<{ city?: string
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "https://schema.org",
-          "@type": "LocalBusiness",
-          "name": "אקו פתרונות אינסטלציה",
-          "image": "https://www.eco-plumbers.com/images/jetter-service.png",
-          "telephone": "+972526736935",
-          "address": {
-            "@type": "PostalAddress",
-            "addressLocality": cityName?.replace("ב", ""),
-            "addressCountry": "IL"
-          },
-          "url": `https://www.eco-plumbers.com/services/jetting/${cityName?.replace("ב", "")}`,
-          "openingHours": "24/7"
-        })
-      }} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "LocalBusiness",
+            "name": "אקו פתרונות אינסטלציה",
+            "image": "https://www.eco-plumbers.com/images/jetter-service.png",
+            "telephone": "+972526736935",
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": cityName?.replace("ב", ""),
+              "addressCountry": "IL"
+            },
+            "url": `https://www.eco-plumbers.com/services/jetting/${cityName?.replace("ב", "")}`,
+            "openingHours": "24/7"
+          })
+        }}
+      />
     </Head>
     <div className="relative overflow-hidden rtl">
       <div className="absolute top-20 -left-20 w-80 h-80 bg-secondary-text rounded-full opacity-20" />
@@ -130,9 +134,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
             <span className="font-bold">התחייבות לשירות מקצועי – לא פתרנו? לא שילמתם.</span><br />
             זמינות גם בשבתות וחגים.
           </p>
-          <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+          <ConversionLink
+            href="tel:0526736935"
+            sendTo="AW-17385017560/B-xnCPSPyfcaENih6eFA"
+            className={filledButton + " m-auto mt-8 block"}
+          >
             ☎️ התקשרו עכשיו וקבלו צילום קו במתנה עם כל שירות: 052-6736935
-          </a>
+          </ConversionLink>
           <a target="blank" href="https://www.midrag.co.il/SpCard/Sp/128232?sectorId=4&listId=2" className={filledButton + " m-auto mt-8 block bg-pink-600 "}>
             ⭐ קראו את הביקורות שלנו באתר מידרג
           </a>
@@ -167,9 +175,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                   <li>שירות חירום 24/7</li>
                 </ul>
               </div>
-              <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+              <ConversionLink
+                href="tel:0526736935"
+                sendTo="AW-17385017560/B-xnCPSPyfcaENih6eFA"
+                className={filledButton + " m-auto mt-8 block"}
+              >
                 ☎️ אני רוצה שתגיעו!
-              </a>
+              </ConversionLink>
             </div>
           </section>
         </div>
@@ -191,9 +203,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
 
         {/* FAQ Accordion */}
         <TogglesGenerator questions={items} />
-        <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+        <ConversionLink
+          href="tel:0526736935"
+          sendTo="AW-17385017560/B-xnCPSPyfcaENih6eFA"
+          className={filledButton + " m-auto mt-8 block"}
+        >
           ☎️ יש לכם עוד שאלות? התקשרו לייעוץ חינם!
-        </a>
+        </ConversionLink>
 
         {/* Testimonial */}
         <div className="bg-gray-50 py-12 px-6 md:px-20 text-center flex flex-col gap-6 justify-center items-center">
@@ -208,9 +224,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
           <p className="mb-6 text-lg text-primary-text">
             השאר פרטים ונחזור תוך דקות – או התקשר עכשיו ואנחנו מגיעים עם ביובית מקצועית וציוד מתקדם
           </p>
-          <a href="https://wa.me/972526736935" className={filledButton + " mt-4 bg-green-600"}>
+          <ConversionLink
+            href="https://wa.me/972526736935"
+            sendTo="AW-17385017560/_ZT_CPPR3vsaENih6eFA"
+            className={filledButton + " mt-4 bg-green-600"}
+          >
             💬 שלחו לנו וואטסאפ עכשיו
-          </a>
+          </ConversionLink>
 
         </div>
 

--- a/app/services/leak-detection/[[...city]]/page.tsx
+++ b/app/services/leak-detection/[[...city]]/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { filledButton } from "@/components/buttons";
 import TogglesGenerator from "@/components/toggles-generator";
 import ReviewsSlider from "@/sections/reviews";
+import ConversionLink from "@/components/ConversionLink";
 
 const items = [
     {
@@ -69,6 +70,7 @@ export default async function Page({ params }: { params: Promise<{ city?: string
     const cityName = city ? "ב" + decodeURIComponent(city[0]) : null;
 
     return (
+        <>
         <div className="relative overflow-hidden rtl">
             <div className="absolute top-20 -left-20 w-80 h-80 bg-secondary-text rounded-full opacity-20" />
             <div className="absolute -bottom-20 -right-20 w-40 h-40 bg-secondary-text rounded-full opacity-20" />
@@ -84,9 +86,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                     <p className="text-lg md:text-xl max-w-3xl mx-auto text-primary-sea ">
                         מצלמות תרמיות, ציוד אקוסטי, דוחות מקצועיים ופתרון מדויק – בלי לנחש, בלי לשבור, בלי הפתעות, עובדים מסביב לשעון גם בשבתות וחגים, מתחייבים לשירות הטוב ביותר , <span className="font-bold">לא איתרנו, לא שילמתם</span>!
                     </p>
-                    <a href="tel:0526736935" className={filledButton + " m-auto mt-8 block"}>
+                    <ConversionLink
+                        href="tel:0526736935"
+                        sendTo="AW-17385017560/pZqJCLDbyfcaENih6eFA"
+                        className={filledButton + " m-auto mt-8 block"}
+                    >
                         ☎️ רוצים שנאתר את הנזילה עוד היום? התקשרו - 052-6736935
-                    </a>
+                    </ConversionLink>
                     <a target="blank" href="https://www.midrag.co.il/SpCard/Sp/128232?sectorId=4&listId=2" className={filledButton + " m-auto mt-8 block bg-pink-600 "}>
                         לכל הביקורות שלנו באתר מידרג
                     </a>
@@ -122,9 +128,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                                 </ul>
                             </div>
 
-                            <a href="tel:0526736935" className={filledButton + " m-auto mt-10 block  text-center"}>
+                            <ConversionLink
+                                href="tel:0526736935"
+                                sendTo="AW-17385017560/pZqJCLDbyfcaENih6eFA"
+                                className={filledButton + " m-auto mt-10 block  text-center"}
+                            >
                                 לא בטוחים? לחצו כאן לשיחת יעוץ חינם
-                            </a>
+                            </ConversionLink>
                         </div>
                     </section>
                 </div>
@@ -163,9 +173,13 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                             </div>
                         </div>
                     </section>
-                    <a href="tel:0526736935" className={filledButton + " m-auto mt-8"}>
+                    <ConversionLink
+                        href="tel:0526736935"
+                        sendTo="AW-17385017560/pZqJCLDbyfcaENih6eFA"
+                        className={filledButton + " m-auto mt-8"}
+                    >
                         ☎️ לשיחת ייעוץ חינם חייגו
-                    </a>
+                    </ConversionLink>
                 </div>
 
                 {/* FAQ Accordion */}
@@ -184,13 +198,18 @@ export default async function Page({ params }: { params: Promise<{ city?: string
                     <p className="mb-6 text-lg text-primary-text">
                         השאר פרטים ונחזור אליך תוך דקות – או התקשר עכשיו ונגיע עם ציוד תרמי לאיתור מיידי
                     </p>
-                    <a href="tel:0526736935" className={filledButton}>
+                    <ConversionLink
+                        href="tel:0526736935"
+                        sendTo="AW-17385017560/pZqJCLDbyfcaENih6eFA"
+                        className={filledButton}
+                    >
                         ☎️ דברו איתנו עכשיו
-                    </a>
+                    </ConversionLink>
                 </div>
 
                 <ContactSection />
             </div>
         </div>
+        </>
     );
 }

--- a/app/services/no-dig-solutions/[[...city]]/page.tsx
+++ b/app/services/no-dig-solutions/[[...city]]/page.tsx
@@ -2,6 +2,7 @@ import ContactSection from "@/sections/contact-section";
 import Image from "next/image";
 import { filledButton } from "@/components/buttons";
 import TogglesGenerator from "@/components/toggles-generator";
+import ConversionLink from "@/components/ConversionLink";
 
 const items = [
   {
@@ -64,6 +65,7 @@ export default async function Page({ params }: { params: Promise<{ city?: string
   const cityName = city ? "ב" + decodeURIComponent(city[0]) : null;
 
   return (
+    <>
     <div className="relative overflow-hidden rtl">
       <div className="absolute top-20 -left-20 w-80 h-80 bg-secondary-text rounded-full opacity-20" />
       <div className="absolute -bottom-20 -right-20 w-40 h-40 bg-secondary-text rounded-full opacity-20" />
@@ -155,13 +157,18 @@ export default async function Page({ params }: { params: Promise<{ city?: string
           <p className="mb-6 text-lg text-primary-text">
             השאר פרטים ונחזור אליך – או התקשר עכשיו ונתאם ביקור לבדיקה וצילום קו
           </p>
-          <a href="tel:0526736935" className={filledButton}>
+          <ConversionLink
+            href="tel:0526736935"
+            sendTo="AW-17385017560/kVxnCL--vPcaENih6eFA"
+            className={filledButton}
+          >
             ☎️ דברו איתנו עכשיו
-          </a>
+          </ConversionLink>
         </div>
 
         <ContactSection />
       </div>
     </div>
+    </>
   );
 }

--- a/components/ConversionLink.tsx
+++ b/components/ConversionLink.tsx
@@ -1,0 +1,22 @@
+'use client';
+import React from 'react';
+import { reportConversion } from '@/lib/gtag';
+
+interface Props {
+  href: string;
+  sendTo: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export default function ConversionLink({ href, sendTo, className, children }: Props) {
+  const handleClick = () => {
+    reportConversion(sendTo);
+  };
+
+  return (
+    <a href={href} onClick={handleClick} className={className}>
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- centralize Google Ads gtag script in root layout
- add reusable ConversionLink component for phone/WhatsApp conversion events
- wire service pages to use ConversionLink for call-to-action tracking

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (requires ESLint configuration)
- `npm run build` (fails: Failed to fetch font `Geist` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_688da964e5d0832c95fe9f8f1b90e1bf